### PR TITLE
Fixed indentation for fluentd

### DIFF
--- a/fluentd-es/templates/daemonset.yaml
+++ b/fluentd-es/templates/daemonset.yaml
@@ -37,7 +37,7 @@ spec:
       priorityClassName: node-critical
       serviceAccountName: {{ .Release.Name }}
       tolerations:
-        {{ toYaml .Values.tolerations | indent 8 }}
+{{ toYaml .Values.tolerations | indent 8 }}
       containers:
       - name: {{  template "fluentd-es.fullname" . }}
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}


### PR DESCRIPTION
Helm deployment was failing in test clusters with

```console
Error: rpc error: code = Unknown desc = YAML parse error on fluentd-es/templates/daemonset.yaml: error converting YAML to JSON: yaml: line 39: did not find expected key
```

This PR fixes it.