### PR TITLE
increase CPU limit of the fluentd daemonset

### DIFF
--- a/fluentd-es/templates/daemonset.yaml
+++ b/fluentd-es/templates/daemonset.yaml
@@ -50,7 +50,7 @@ spec:
           value: {{ .Values.fluent_kubernetes_cluster_name }}
         resources:
           limits:
-            cpu: 500m
+            cpu: 1000m
             memory: 1000Mi
           requests:
             cpu: 10m


### PR DESCRIPTION
The fluentd pods running on master require more cpu cores than what is currently allocated. 

This PR increases the CPU limit to 1000 milicores.
