### PR TITLE
Add a github action to keep "gh-pages" updated

### DIFF
--- a/.github/workflows/sync-branches.yml
+++ b/.github/workflows/sync-branches.yml
@@ -1,0 +1,13 @@
+name: Keep gh-pages in sync wrt. main
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - run: git checkout -b gh-pages
+      - run: git push origin gh-pages --force


### PR DESCRIPTION
This should enable us to switch the default branch of this repo to
"main" and still publish our github pages site by publishing from the
`gh-pages` branch, which will be kept updated wrt. any changes on `main`
by this github action.