### PR TITLE
Update api version for k8s upgrade to 1.16

### DIFF
--- a/prometheus-ecr-exporter/Chart.yaml
+++ b/prometheus-ecr-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.1.0"
 description: A Helm chart for prometheus ecr-exporter
 name: prometheus-ecr-exporter
-version: 0.1.0
+version: 0.2.0
 home: https://github.com/ministryofjustice/prometheus_ecr_exporter
 sources:
 - https://github.com/ministryofjustice/prometheus_ecr_exporter

--- a/prometheus-ecr-exporter/templates/deployment.yaml
+++ b/prometheus-ecr-exporter/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "prometheus-ecr-exporter.fullname" . }}


### PR DESCRIPTION
Update api versions for the ecr-exporter from v1beta2 for v1 as the pervious version is being deprecated on kubernetes v1.16